### PR TITLE
Fix formatting of Traefik labels in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,11 +31,11 @@ services:
       - ./certs-traefik.yml:/etc/traefik/dynamic/certs-traefik.yml
       - /etc/ssl:/etc/ssl
     labels:
-      - traefik.enable = true
+      - traefik.enable=true
       - traefik.http.routers.traefik-dashboard.rule=Host(`traefik.amfoss.in`)
-      - traefik.http.routers.traefik-dashboard.entrypoint=websecure
-      - traefik.http.router.traefik-dashboard.service=api@internal
-      - traefik.http.router.traefik-dashboard.tls=true
+      - traefik.http.routers.traefik-dashboard.entrypoints=websecure
+      - traefik.http.routers.traefik-dashboard.service=api@internal
+      - traefik.http.routers.traefik-dashboard.tls=true
       - traefik.http.routers.traefik-dashboard.middlewares=traefik-dashboard-auth
       - traefik.http.middlewares.traefik-dashboard-auth.basicauth.usersfile=/etc/traefik/secret/traefik-htpasswd
 


### PR DESCRIPTION
This pull request updates the Traefik configuration in the `docker-compose.yml` file to correct a label key and ensure the dashboard is properly routed and secured. The main change is fixing the label for the Traefik dashboard entrypoint to use the correct key.

**Traefik configuration fix:**

* Changed the label from `traefik.http.routers.traefik-dashboard.entrypoint` to `traefik.http.routers.traefik-dashboard.entrypoints` to match Traefik's expected configuration and ensure the dashboard is accessible via the correct entrypoint.
* Corrected the label keys for the Traefik dashboard service and TLS to use the proper prefix (`routers` instead of `router`), which aligns with Traefik's label conventions.