### PR TITLE
Add CloudBeaver for UI-based database administration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,6 +120,22 @@ services:
     labels:
       - com.centurylinklabs.watchtower.enable=false
     <<: *env
-
+  cloudbeaver:
+    container_name: cloudbeaver
+    image: dbeaver/cloudbeaver:latest
+    restart: always
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - cloudbeaver_data:/opt/cloudbeaver/workspace
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.cloudbeaver.tls=true
+      - traefik.http.routers.cloudbeaver.entrypoints=websecure
+      - traefik.http.routers.cloudbeaver.rule=Host(`db.${HOSTNAME}`)
+      - traefik.http.services.cloudbeaver.loadbalancer.server.port=8978
+    <<: *env
 volumes:
   db-vol:
+  cloudbeaver_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,13 +128,14 @@ services:
       postgres:
         condition: service_healthy
     volumes:
-      - cloudbeaver_data:/opt/cloudbeaver/workspace
+      - cloudbeaver_data:/opt/cloudbeaver/workspace 
     labels:
       - traefik.enable=true
       - traefik.http.routers.cloudbeaver.tls=true
       - traefik.http.routers.cloudbeaver.entrypoints=websecure
       - traefik.http.routers.cloudbeaver.rule=Host(`db.${HOSTNAME}`)
-      - traefik.http.services.cloudbeaver.loadbalancer.server.port=8978
+      - traefik.http.services.cloudbeaver.loadbalancer.server.port=${CLOUDBEAVER_PORT}
+      - com.centurylinklabs.watchtower.enable=false 
     <<: *env
 volumes:
   db-vol:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,7 +104,7 @@ services:
 
   postgres:
     container_name: postgres
-    image: postgres:alpine
+    image: postgres:alpine  
     restart: always
     command: [ "postgres", "-c", "config_file=/etc/postgresql/postgresql.conf" ]
     volumes:
@@ -122,7 +122,7 @@ services:
     <<: *env
   cloudbeaver:
     container_name: cloudbeaver
-    image: dbeaver/cloudbeaver:latest
+    image: dbeaver/cloudbeaver:25.3.3
     restart: always
     depends_on:
       postgres:


### PR DESCRIPTION
**What this PR does**
Related to https://github.com/amfoss/ammentor-backend/issues/90
This PR introduces CloudBeaver as part of the infrastructure to enable web-based PostgreSQL management for the amMentor backend.

Instead of SSH-ing into the VM, exec-ing into the Postgres container, and running manual SQL commands, CloudBeaver provides a secure UI to manage the database directly.

**What CloudBeaver enables**

- CRUD operations on tables and data (single & bulk)
- Schema inspection and controlled modifications
- Multi-database access within the same Postgres instance
- UI-based workflows instead of SSH + psql
- No exposure of Postgres ports to the public internet

**Scope and safety**

- This does not replace application-level admin logic
- It is intended for infrastructure and maintenance use
- Database access remains restricted via credentials
- No changes are made to application runtime behavior